### PR TITLE
Fix issue #11

### DIFF
--- a/image-files/tws-scripts/run_tws.sh
+++ b/image-files/tws-scripts/run_tws.sh
@@ -20,8 +20,8 @@ disable_agents() {
 		xfconf-query -c xfce4-session -p /startup/ssh-agent/enabled -n -t bool -s false
 		xfconf-query -c xfce4-session -p /startup/gpg-agent/enabled -n -t bool -s false
 		# kill ssh-agent and gpg-agent
-		pkill -x ssh-agent
-		pkill -x gpg-agent
+		pkill -x ssh-agent || echo ".> ssh-agent was not running."
+		pkill -x gpg-agent || echo ".> gpg-agent was not running."
 		touch /config/.config/disable_agents
 	else
 		echo ".> Found '/config/.config/disable_agents' agents already disabled"


### PR DESCRIPTION
To address issue #11

- pkill ssh-agent/gpg-agent can return error in case agents are not running.
- added code that handles that case