### PR TITLE
Feat/native aarch64

### DIFF
--- a/.github/workflows/detect-releases.yml
+++ b/.github/workflows/detect-releases.yml
@@ -48,10 +48,14 @@ jobs:
       - name: Download
         if: ${{ steps.check-update.outputs.has_update == 'true' }}
         run: |
-          download_url='https://download2.interactivebrokers.com/installers/ibgateway/${{ matrix.channel }}-standalone/ibgateway-${{ matrix.channel }}-standalone-linux-x64.sh'
-          dest='ibgateway-${{ steps.version.outputs.build_version }}-standalone-linux-x64.sh'
-          curl -sSL "$download_url" --output "$dest"
-          sha256sum "$dest" > "${dest}.sha256"
+          archs="x64 arm"
+          for arch in $archs
+          do
+            download_url='https://download2.interactivebrokers.com/installers/ibgateway/${{ matrix.channel }}-standalone/ibgateway-${{ matrix.channel }}-standalone-linux-'$arch'x64.sh'
+            dest='ibgateway-${{ steps.version.outputs.build_version }}-standalone-linux-'$arch'x64.sh'
+            curl -sSL "$download_url" --output "$dest"
+            sha256sum "$dest" > "${dest}.sha256"
+          done
 
       - name: Create release
         if: ${{ steps.check-update.outputs.has_update == 'true' }}

--- a/.github/workflows/detect-releases.yml
+++ b/.github/workflows/detect-releases.yml
@@ -51,8 +51,8 @@ jobs:
           archs="x64 arm"
           for arch in $archs
           do
-            download_url='https://download2.interactivebrokers.com/installers/ibgateway/${{ matrix.channel }}-standalone/ibgateway-${{ matrix.channel }}-standalone-linux-'$arch'x64.sh'
-            dest='ibgateway-${{ steps.version.outputs.build_version }}-standalone-linux-'$arch'x64.sh'
+            download_url="https://download2.interactivebrokers.com/installers/ibgateway/${{ matrix.channel }}-standalone/ibgateway-${{ matrix.channel }}-standalone-linux-${arch}.sh"
+            dest="ibgateway-${{ steps.version.outputs.build_version }}-standalone-linux-${arch}.sh"
             curl -sSL "$download_url" --output "$dest"
             sha256sum "$dest" > "${dest}.sha256"
           done

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -12,15 +12,10 @@ ENV IB_GATEWAY_VERSION=$VERSION
 ENV IB_GATEWAY_CHANNEL=$CHANNEL
 ENV IBC_VERSION=3.23.0
 ARG DEBIAN_FRONTEND=noninteractive
-ARG IB_GATEWAY_FILE="ibgateway-${IB_GATEWAY_VERSION}-standalone-linux-x64.sh"
 ARG IB_GATEWAY_REPO="https://github.com/gnzsnz/ib-gateway-docker"
-ARG IB_GATEWAY_URL="${IB_GATEWAY_REPO}/releases/download/ibgateway-${IB_GATEWAY_CHANNEL}%40${IB_GATEWAY_VERSION}/${IB_GATEWAY_FILE}"
 ARG IBC_FILE="IBCLinux-${IBC_VERSION}.zip"
 ARG IBC_REPO="https://github.com/IbcAlpha/IBC"
 ARG IBC_URL="${IBC_REPO}/releases/download/${IBC_VERSION}/${IBC_FILE}"
-ARG ZULU_NAME=zulu17.60.17-ca-fx-jre17.0.16-linux_aarch64
-ARG ZULU_FILE=${ZULU_NAME}.tar.gz
-ARG ZULU_URL=https://cdn.azul.com/zulu/bin/${ZULU_FILE}
 
 WORKDIR /tmp/setup
 
@@ -31,26 +26,24 @@ RUN apt-get update -y && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
   if [ "$(uname -m)" = "aarch64" ]; then \
-    curl -sSLO ${ZULU_URL} ; \
-    tar -xzf ${ZULU_FILE} -C /usr/local/ ; \
-    ln -s /usr/local/${ZULU_NAME} /usr/local/zulu17 ; \
+     ARCH="arm" ; \
+  else \
+     ARCH="x64" ; \
   fi && \
+  IB_GATEWAY_FILE="ibgateway-${IB_GATEWAY_VERSION}-standalone-linux-${ARCH}.sh" && \
+  IB_GATEWAY_URL="${IB_GATEWAY_REPO}/releases/download/ibgateway-${IB_GATEWAY_CHANNEL}%40${IB_GATEWAY_VERSION}/${IB_GATEWAY_FILE}" && \
 # Install IB Gateway
 # Use this instead of "RUN curl .." to install a local file:
 #COPY ibgateway-${IB_GATEWAY_VERSION}-standalone-linux-x64.sh .
-  curl -sSOL ${IB_GATEWAY_URL} && \
-  curl -sSOL ${IB_GATEWAY_URL}.sha256 && \
-  sha256sum --check ./${IB_GATEWAY_FILE}.sha256 &&\
-  chmod a+x ./${IB_GATEWAY_FILE} && \
-  if [ "$(uname -m)" = "aarch64" ]; then \
-    app_java_home=/usr/local/zulu17 ./${IB_GATEWAY_FILE} -q -dir /root/Jts/ibgateway/${IB_GATEWAY_VERSION} ; \
-  else \
-    ./${IB_GATEWAY_FILE} -q -dir /root/Jts/ibgateway/${IB_GATEWAY_VERSION} ; \
-  fi && \
+  curl -sSOL "${IB_GATEWAY_URL}" && \
+  curl -sSOL "${IB_GATEWAY_URL}.sha256" && \
+  sha256sum --check "./${IB_GATEWAY_FILE}.sha256" &&\
+  chmod a+x "./${IB_GATEWAY_FILE}" && \
+  "./${IB_GATEWAY_FILE}" -q -dir "/root/Jts/ibgateway/${IB_GATEWAY_VERSION}" && \
   # Install IBC
-  curl -sSOL ${IBC_URL} && \
+  curl -sSOL "${IBC_URL}" && \
   mkdir /root/ibc && \
-  unzip ./${IBC_FILE} -d /root/ibc && \
+  unzip "./${IBC_FILE}" -d /root/ibc && \
   chmod -R u+x /root/ibc/*.sh && \
   chmod -R u+x /root/ibc/scripts/*.sh
 

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -12,45 +12,38 @@ ENV IB_GATEWAY_VERSION=10.46.1g
 ENV IB_GATEWAY_CHANNEL=latest
 ENV IBC_VERSION=3.23.0
 ARG DEBIAN_FRONTEND=noninteractive
-ARG IB_GATEWAY_FILE="ibgateway-${IB_GATEWAY_VERSION}-standalone-linux-x64.sh"
 ARG IB_GATEWAY_REPO="https://github.com/gnzsnz/ib-gateway-docker"
-ARG IB_GATEWAY_URL="${IB_GATEWAY_REPO}/releases/download/ibgateway-${IB_GATEWAY_CHANNEL}%40${IB_GATEWAY_VERSION}/${IB_GATEWAY_FILE}"
 ARG IBC_FILE="IBCLinux-${IBC_VERSION}.zip"
 ARG IBC_REPO="https://github.com/IbcAlpha/IBC"
 ARG IBC_URL="${IBC_REPO}/releases/download/${IBC_VERSION}/${IBC_FILE}"
-ARG ZULU_NAME=zulu17.60.17-ca-fx-jre17.0.16-linux_aarch64
-ARG ZULU_FILE=${ZULU_NAME}.tar.gz
-ARG ZULU_URL=https://cdn.azul.com/zulu/bin/${ZULU_FILE}
 
 WORKDIR /tmp/setup
 
 # Prepare system
 RUN apt-get update -y && \
-  apt-get install --no-install-recommends --yes \
+  apt-get install --no-install-recommends --yes && \
   curl ca-certificates unzip && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
   if [ "$(uname -m)" = "aarch64" ]; then \
-    curl -sSLO ${ZULU_URL} ; \
-    tar -xzf ${ZULU_FILE} -C /usr/local/ ; \
-    ln -s /usr/local/${ZULU_NAME} /usr/local/zulu17 ; \
+     ARCH="arm" ; \
+  else \
+     ARCH="x64" ; \
   fi && \
+  IB_GATEWAY_FILE="ibgateway-${IB_GATEWAY_VERSION}-standalone-linux-${ARCH}.sh" && \
+  IB_GATEWAY_URL="${IB_GATEWAY_REPO}/releases/download/ibgateway-${IB_GATEWAY_CHANNEL}%40${IB_GATEWAY_VERSION}/${IB_GATEWAY_FILE}" && \
 # Install IB Gateway
 # Use this instead of "RUN curl .." to install a local file:
 #COPY ibgateway-${IB_GATEWAY_VERSION}-standalone-linux-x64.sh .
-  curl -sSOL ${IB_GATEWAY_URL} && \
-  curl -sSOL ${IB_GATEWAY_URL}.sha256 && \
-  sha256sum --check ./${IB_GATEWAY_FILE}.sha256 &&\
-  chmod a+x ./${IB_GATEWAY_FILE} && \
-  if [ "$(uname -m)" = "aarch64" ]; then \
-    app_java_home=/usr/local/zulu17 ./${IB_GATEWAY_FILE} -q -dir /root/Jts/ibgateway/${IB_GATEWAY_VERSION} ; \
-  else \
-    ./${IB_GATEWAY_FILE} -q -dir /root/Jts/ibgateway/${IB_GATEWAY_VERSION} ; \
-  fi && \
+  curl -sSOL "${IB_GATEWAY_URL}" && \
+  #curl -sSOL ${IB_GATEWAY_URL}.sha256 && \
+  #sha256sum --check ./${IB_GATEWAY_FILE}.sha256 &&\
+  chmod a+x "./${IB_GATEWAY_FILE}" && \
+  "./${IB_GATEWAY_FILE}" -q -dir "/root/Jts/ibgateway/${IB_GATEWAY_VERSION}" && \
   # Install IBC
-  curl -sSOL ${IBC_URL} && \
+  curl -sSOL "${IBC_URL}" && \
   mkdir /root/ibc && \
-  unzip ./${IBC_FILE} -d /root/ibc && \
+  unzip "./${IBC_FILE}" -d /root/ibc && \
   chmod -R u+x /root/ibc/*.sh && \
   chmod -R u+x /root/ibc/scripts/*.sh
 

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -8,42 +8,49 @@
 # hadolint global ignore=DL3008,DL4006
 FROM ubuntu:24.04 AS setup
 
-ENV IB_GATEWAY_VERSION=10.46.1g
+ENV IB_GATEWAY_VERSION=10.47.1e
 ENV IB_GATEWAY_CHANNEL=latest
 ENV IBC_VERSION=3.23.0
 ARG DEBIAN_FRONTEND=noninteractive
+ARG IB_GATEWAY_FILE="ibgateway-${IB_GATEWAY_VERSION}-standalone-linux-x64.sh"
 ARG IB_GATEWAY_REPO="https://github.com/gnzsnz/ib-gateway-docker"
+ARG IB_GATEWAY_URL="${IB_GATEWAY_REPO}/releases/download/ibgateway-${IB_GATEWAY_CHANNEL}%40${IB_GATEWAY_VERSION}/${IB_GATEWAY_FILE}"
 ARG IBC_FILE="IBCLinux-${IBC_VERSION}.zip"
 ARG IBC_REPO="https://github.com/IbcAlpha/IBC"
 ARG IBC_URL="${IBC_REPO}/releases/download/${IBC_VERSION}/${IBC_FILE}"
+ARG ZULU_NAME=zulu17.60.17-ca-fx-jre17.0.16-linux_aarch64
+ARG ZULU_FILE=${ZULU_NAME}.tar.gz
+ARG ZULU_URL=https://cdn.azul.com/zulu/bin/${ZULU_FILE}
 
 WORKDIR /tmp/setup
 
 # Prepare system
 RUN apt-get update -y && \
-  apt-get install --no-install-recommends --yes && \
+  apt-get install --no-install-recommends --yes \
   curl ca-certificates unzip && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
   if [ "$(uname -m)" = "aarch64" ]; then \
-     ARCH="arm" ; \
-  else \
-     ARCH="x64" ; \
+    curl -sSLO ${ZULU_URL} ; \
+    tar -xzf ${ZULU_FILE} -C /usr/local/ ; \
+    ln -s /usr/local/${ZULU_NAME} /usr/local/zulu17 ; \
   fi && \
-  IB_GATEWAY_FILE="ibgateway-${IB_GATEWAY_VERSION}-standalone-linux-${ARCH}.sh" && \
-  IB_GATEWAY_URL="${IB_GATEWAY_REPO}/releases/download/ibgateway-${IB_GATEWAY_CHANNEL}%40${IB_GATEWAY_VERSION}/${IB_GATEWAY_FILE}" && \
 # Install IB Gateway
 # Use this instead of "RUN curl .." to install a local file:
 #COPY ibgateway-${IB_GATEWAY_VERSION}-standalone-linux-x64.sh .
-  curl -sSOL "${IB_GATEWAY_URL}" && \
-  #curl -sSOL ${IB_GATEWAY_URL}.sha256 && \
-  #sha256sum --check ./${IB_GATEWAY_FILE}.sha256 &&\
-  chmod a+x "./${IB_GATEWAY_FILE}" && \
-  "./${IB_GATEWAY_FILE}" -q -dir "/root/Jts/ibgateway/${IB_GATEWAY_VERSION}" && \
+  curl -sSOL ${IB_GATEWAY_URL} && \
+  curl -sSOL ${IB_GATEWAY_URL}.sha256 && \
+  sha256sum --check ./${IB_GATEWAY_FILE}.sha256 &&\
+  chmod a+x ./${IB_GATEWAY_FILE} && \
+  if [ "$(uname -m)" = "aarch64" ]; then \
+    app_java_home=/usr/local/zulu17 ./${IB_GATEWAY_FILE} -q -dir /root/Jts/ibgateway/${IB_GATEWAY_VERSION} ; \
+  else \
+    ./${IB_GATEWAY_FILE} -q -dir /root/Jts/ibgateway/${IB_GATEWAY_VERSION} ; \
+  fi && \
   # Install IBC
-  curl -sSOL "${IBC_URL}" && \
+  curl -sSOL ${IBC_URL} && \
   mkdir /root/ibc && \
-  unzip "./${IBC_FILE}" -d /root/ibc && \
+  unzip ./${IBC_FILE} -d /root/ibc && \
   chmod -R u+x /root/ibc/*.sh && \
   chmod -R u+x /root/ibc/scripts/*.sh
 
@@ -59,7 +66,7 @@ COPY ./scripts /root/scripts
 
 FROM ubuntu:24.04
 
-ENV IB_GATEWAY_VERSION=10.46.1g
+ENV IB_GATEWAY_VERSION=10.47.1e
 # IB Gateway user constants
 ARG USER_ID="${USER_ID:-1000}"
 ARG USER_GID="${USER_GID:-1000}"

--- a/latest/Dockerfile.tws
+++ b/latest/Dockerfile.tws
@@ -8,7 +8,9 @@
 # hadolint global ignore=DL3008
 
 ARG IB_VERSION=10.46.1g
-FROM ghcr.io/gnzsnz/ib-gateway:${IB_VERSION} AS setup
+#FROM ghcr.io/gnzsnz/ib-gateway:${IB_VERSION} AS setup
+FROM ghcr.io/gnzsnz/ib-gateway:latest-arm AS setup
+
 
 WORKDIR /
 

--- a/latest/Dockerfile.tws
+++ b/latest/Dockerfile.tws
@@ -7,10 +7,8 @@
 
 # hadolint global ignore=DL3008
 
-ARG IB_VERSION=10.46.1g
-#FROM ghcr.io/gnzsnz/ib-gateway:${IB_VERSION} AS setup
-FROM ghcr.io/gnzsnz/ib-gateway:latest-arm AS setup
-
+ARG IB_VERSION=10.47.1e
+FROM ghcr.io/gnzsnz/ib-gateway:${IB_VERSION} AS setup
 
 WORKDIR /
 
@@ -20,7 +18,7 @@ WORKDIR /
 
 FROM lscr.io/linuxserver/rdesktop:ubuntu-xfce
 
-ENV IB_GATEWAY_VERSION=10.46.1g
+ENV IB_GATEWAY_VERSION=10.47.1e
 ENV IB_GATEWAY_RELEASE_CHANNEL=latest
 ENV IBC_VERSION=3.23.0
 

--- a/template_README.md
+++ b/template_README.md
@@ -579,7 +579,10 @@ value in seconds defined in `SSH_RESTART`.
 
 ## aarch64 support
 
-This is experimental, so expects bugs.
+IBKR's has started releasing an installer for `linux-arm`. And this image is
+using it. While the official installer is for `ib-gateway`, we provide an TWS
+image too. So please take into account that TWS image might have unexpected
+bugs.
 
 Please go to discussions section to see common problems. Avoid creating issues unless
 you have empirically probed that is a bug, ie it does not work to me is not a bug.

--- a/template_README.md
+++ b/template_README.md
@@ -28,7 +28,7 @@ It includes:
   `10.19.2g-stable` and `10.25.1o-latest` or greater.
 - Support parallel execution of `live` and `paper` trading mode.
 - [Secrets](#credentials) support (latest `10.29.1e`, stable `10.19.2m` or greater)
-- Experimental [aarch64](#aarch64-support) support, ex raspberry pi, M1,M2,M3,.., since `10.37.1l`/`10.39.1e`
+- [aarch64](#aarch64-support) support, ex raspberry pi, M1,M2,M3,.., since `10.37.1l`/`10.39.1e`
 - Execution of custom scripts during [star-up process](#start-up-scripts).
 - Works well together with [Jupyter Quant](https://github.com/quantbelt/jupyter-quant)
   docker image.


### PR DESCRIPTION
Implement IBKR's linux aarch64 installer.

This will replace the current aarch64 workaround of using amd64 installer with Azul java for aarch64.

Implementation steps:
- get `detect-release.yml` working
- then push updated Dockerfile/Dockerfile.tws
- Current Dockerfile/Dockerfile.tws are on `latest` directory. Both ibgateway and TWS are working with IBKR's aarch64 installer. Although IBKR only publishes ibgateway.
